### PR TITLE
downgrade node on github actions.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x] # We will deploy with only one version of node  
+        node-version: [12.x] # We will deploy with only one version of node  
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
Previously upgraded but turns out I just needed to update a particular action version and this might mean I need to update my code to be compatible with v16.